### PR TITLE
fix: allow returning any values

### DIFF
--- a/fn_tmpl.go
+++ b/fn_tmpl.go
@@ -24,13 +24,14 @@ type Tmpl rootContext
 //	{{ $result := tmpl.Exec "T1" "World" }}
 //	Message: {{ $result }} // Output: Message: Hello World
 func (ctx Tmpl) Exec(name string, data ...any) (any, error) {
+	var arg any
 	var buf bytes.Buffer
 	if len(data) > 1 {
 		return nil, OnlyOneArgumentIsAllowedError{}
-	} else if len(data) == 0 {
-		data = nil
+	} else if len(data) == 1 {
+		arg = data[0]
 	}
-	err := ctx.template.ExecuteTemplate(&buf, name, data)
+	err := ctx.template.ExecuteTemplate(&buf, name, arg)
 	if err != nil {
 		var retErr ReturnError
 		if errors.As(err, &retErr) {

--- a/fn_tmpl.go
+++ b/fn_tmpl.go
@@ -6,6 +6,13 @@ import (
 	"fmt"
 )
 
+// OnlyOneArgumentIsAllowedError indicates that only one argument is allowed.
+type OnlyOneArgumentIsAllowedError struct{}
+
+func (e OnlyOneArgumentIsAllowedError) Error() string {
+	return "only one argument is allowed"
+}
+
 // Tmpl provides enhanced template execution capabilities.
 type Tmpl rootContext
 
@@ -16,13 +23,18 @@ type Tmpl rootContext
 //	{{ define "T1" }}Hello {{ . }}{{ end }}
 //	{{ $result := tmpl.Exec "T1" "World" }}
 //	Message: {{ $result }} // Output: Message: Hello World
-func (ctx Tmpl) Exec(name string, data any) (string, error) {
+func (ctx Tmpl) Exec(name string, data ...any) (any, error) {
 	var buf bytes.Buffer
+	if len(data) > 1 {
+		return nil, OnlyOneArgumentIsAllowedError{}
+	} else if len(data) == 0 {
+		data = nil
+	}
 	err := ctx.template.ExecuteTemplate(&buf, name, data)
 	if err != nil {
 		var retErr ReturnError
 		if errors.As(err, &retErr) {
-			return fmt.Sprint(retErr.Value), nil
+			return retErr.Value, nil
 		}
 		return "", fmt.Errorf("failed to execute partial template %q: %w", name, err)
 	}

--- a/funcs_test.go
+++ b/funcs_test.go
@@ -60,6 +60,16 @@ func TestCommonUseCases(t *testing.T) {
 			want:    "Hello world",
 			wantErr: false,
 		},
+		{
+			name: "template with return dict",
+			tmpl: `
+			{{- define "T1" }}{{ return ( dict.New "name" "Joe" ) }}{{ end -}}
+			{{- $result := tmpl.Exec "T1" -}}
+			Hello {{ $result.name -}}
+			`,
+			want:    "Hello Joe",
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

## Problem
when using `return` we should allow returning arbitrary types not only string.

## Solution
Adjust code to allow returning other types than string.

## Notes
Fixed tmpl.Exec without arguments
